### PR TITLE
Feature/topic prefix ident

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 valetudo_config.json
 maploader-binary
 log/
+maploader-arm64

--- a/config/config_helper.go
+++ b/config/config_helper.go
@@ -38,6 +38,17 @@ func MqttPassword() string {
 	config := getValetudoConfig()
 	return config.Mqtt.Connection.Authentication.Credentials.Password
 }
+
+func MqttIdentifier() string {
+	config := getValetudoConfig()
+	return config.Mqtt.Identity.Identifier
+}
+
+func MqttPrefix() string {
+	config := getValetudoConfig()
+	return config.Mqtt.Customizations.TopicPrefix
+}
+
 func RotationKeepMaps() int {
 	rotationKeepMaps, err := strconv.Atoi(Getenv("ROTATION_KEEP_MAPS", "5"))
 	if err != nil {


### PR DESCRIPTION
Hi,
I wanted to use your changes to pkoehlers/maploader for the addition of the map/save and map/load command topics. Unfortunately, as things are written (in both the original pkoehler repo as well as your fork), the Topic strings are hardcoded, and do not use the MQTT Topic Prefix nor Identifier as defined in the Valetudo configuration. This is a problem for me as I have multiple robots. If the topics are hardcoded, and maploader is running on multiple robots, there is no way to specify which robot the command is supposed to go to. By making use of the prefix and identifier options though, this becomes trivial.

For example:

Original Map Save Command Topic:
/valetudo/maploader/map/save

New Map Save Command Topic:
/mqtt-prefix/mqtt-identifier/maploader/map/save  (e.g., /valetudo/myrobot1/maploader/map/save)

Since my changes are a modification of your changes, and your PR has not been accepted into the main repo yet, I am submitting my PR to you instead.
Thanks!

PS - This is tested and working for me, but I would appreciate you making sure it works as expected for you too.